### PR TITLE
Fixed subtle bug when testing for existence of namespace.

### DIFF
--- a/lib/manager.dart
+++ b/lib/manager.dart
@@ -667,11 +667,8 @@ class Manager {
    * Declares a socket namespace.
    */
   SocketNamespace of(String namespace) {
-    if (this.namespaces[namespace]) {
-      return this.namespaces[namespace];
-    }
-
-    return this.namespaces[namespace] = new SocketNamespace(this, namespace);
+    this.namespaces.putIfAbsent(namespace, () => new SocketNamespace(this, namespace));
+    return this.namespaces[namespace];
   }
 
   /**


### PR DESCRIPTION
I believe that:

``` dart
if (this.namespaces[namespace])
```

works in Javascript but will be false with Dart.

See https://www.dartlang.org/docs/dart-up-and-running/contents/ch02.html#booleans. Feel free to reject if I have this all wrong.
